### PR TITLE
Support Google Cloud Storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ WORKDIR /usr/src/app
 COPY package.json /usr/src/app/
 RUN apt-get update -y && apt-get upgrade -y && \
     apt-get install -y nodejs npm libcairo2-dev libjpeg62-turbo-dev libpango1.0-dev libgif-dev libpng-dev build-essential g++ ffmpeg
-COPY ./ /usr/src/app/
+COPY package.json* yarn.lock* .npmrc* /usr/src/app/
 RUN npm install --production
+
+COPY ./ /usr/src/app/
 
 EXPOSE 8888
 CMD [ "npm", "start" ]

--- a/lib/transports/s3/remote.js
+++ b/lib/transports/s3/remote.js
@@ -5,7 +5,7 @@ module.exports = function(bucket, storagePath) {
 
   var s3Options = { params: { Bucket: bucket } };
   if (process.env.S3_ENDPOINT) {
-    S3Options.endpoint = process.env.S3_ENDPOINT;
+    s3Options.endpoint = process.env.S3_ENDPOINT;
   }
   var s3 = new AWS.S3(s3Options);
 

--- a/lib/transports/s3/remote.js
+++ b/lib/transports/s3/remote.js
@@ -3,7 +3,10 @@ var AWS = require("aws-sdk"),
 
 module.exports = function(bucket, storagePath) {
 
-  var s3 = new AWS.S3({ params: { Bucket: bucket } });
+  var s3 = new AWS.S3({
+    params: { Bucket: bucket },
+    endpoint: process.env.S3_ENDPOINT || 's3.amazonaws.com'
+  });
 
   // Test credentials
   s3.headBucket({}, function(err){ if (err) { throw err; } });
@@ -12,12 +15,11 @@ module.exports = function(bucket, storagePath) {
 
     var params = {
       Key: storagePath + key,
-      Body: fs.createReadStream(source),
-      ACL: "public-read"
+      Body: fs.createReadStream(source)
     };
 
     // gzipping results in inconsistent file size :(
-    s3.upload(params, cb);
+    s3.putObject(params, cb);
 
   }
 
@@ -71,7 +73,7 @@ module.exports = function(bucket, storagePath) {
 
   // TODO make this more configurable
   function getURL(id) {
-    return "https://s3.amazonaws.com/" + bucket + "/" + storagePath + "video/" + id + ".mp4";
+    return "https://" + bucket + "/" + storagePath + "video/" + id + ".mp4";
   }
 
   return {

--- a/lib/transports/s3/remote.js
+++ b/lib/transports/s3/remote.js
@@ -3,10 +3,11 @@ var AWS = require("aws-sdk"),
 
 module.exports = function(bucket, storagePath) {
 
-  var s3 = new AWS.S3({
-    params: { Bucket: bucket },
-    endpoint: process.env.S3_ENDPOINT || 's3.amazonaws.com'
-  });
+  var s3Options = { params: { Bucket: bucket } };
+  if (process.env.S3_ENDPOINT) {
+    S3Options.endpoint = process.env.S3_ENDPOINT;
+  }
+  var s3 = new AWS.S3(s3Options);
 
   // Test credentials
   s3.headBucket({}, function(err){ if (err) { throw err; } });


### PR DESCRIPTION
Made a few changes to support google cloud storage:
* use the `s3.putObject` method, instead of `s3.upload` (not sure why the original version used this, putObject is more standard and is what google supports as well)
* allow specifying a `S3_ENDPOINT` variable, which can now be set to `storage.googleapis.com`

Tried running this branch is staging, and things seem to be okay so far. Only changes I had to make in the config was set the `S3_ENDPOINT` variable, and use a new set of aws credentials that work for Google instead.